### PR TITLE
fix: stop using NodePort for registry services

### DIFF
--- a/mirroroperator/registrymirror.py
+++ b/mirroroperator/registrymirror.py
@@ -255,7 +255,7 @@ class RegistryMirror(object):
         return daemon_set
 
     def generate_service(self, service):
-        service.spec.type = "NodePort"
+        service.spec.type = "ClusterIP"
         return service
 
     def generate_headless_service(self, service_headless):


### PR DESCRIPTION
ref: osp-cfc-platform/backlog#693