### PR TITLE
feat: upgrade to more recent API and client

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.6-alpine
+FROM python:3.8-alpine3.12
 RUN apk --no-cache add curl
 COPY . ./app
 WORKDIR /app

--- a/mirroroperator/operator.py
+++ b/mirroroperator/operator.py
@@ -41,23 +41,37 @@ class MirrorOperator(object):
     def watch_registry_mirrors(self):
         watcher = kubernetes.watch.Watch()
         try:
-            for event in watcher.stream(self.object_api.list_cluster_custom_object, CRD_GROUP, CRD_VERSION, CRD_PLURAL):
+            for event in watcher.stream(
+                self.object_api.list_cluster_custom_object,
+                CRD_GROUP,
+                CRD_VERSION,
+                CRD_PLURAL
+            ):
                 registry_mirror_kwargs = event['object'].copy()
                 registry_mirror_kwargs.update(self.registry_mirror_vars)
-                mirror = RegistryMirror(event_type=event['type'], **registry_mirror_kwargs)
+                LOGGER.debug("RM kwargs: {}".format(registry_mirror_kwargs))
+                mirror = RegistryMirror(
+                    event_type=event['type'], **registry_mirror_kwargs
+                )
                 mirror.apply()
         except ApiException as e:
             status = HTTPStatus(e.status)
             if status == HTTPStatus.NOT_FOUND:
-                raise NoCRDException("CRD not found. Please ensure you create a CRD with group - %s,"
-                                     "version - %s and plural - %s before this operator can run.",
-                                     CRD_GROUP, CRD_VERSION, CRD_PLURAL)
+                raise NoCRDException(
+                    "CRD not found. Please ensure you create a CRD with group"
+                    " - %s, version - %s and plural - %s before this operator"
+                    " can run.",
+                    CRD_GROUP, CRD_VERSION, CRD_PLURAL)
             else:
-                LOGGER.exception("Error watching custom object events", exc_info=True)
+                LOGGER.exception(
+                    "Error watching custom object events",
+                    exc_info=True
+                )
 
 
 def safely_eval_env(env_var):
-    return ast.literal_eval(os.environ.get(env_var)) if os.environ.get(env_var) is not None else None
+    return ast.literal_eval(os.environ.get(env_var)
+                            ) if os.environ.get(env_var) is not None else None
 
 
 if __name__ == '__main__':
@@ -67,7 +81,8 @@ if __name__ == '__main__':
     env_vars = dict(
         namespace=os.environ.get("NAMESPACE", "default"),
         # optional to allow for image to be pulled from elsewhere
-        hostess_docker_registry=os.environ.get("HOSTESS_DOCKER_REGISTRY", "docker.io"),
+        hostess_docker_registry=os.environ.get(
+            "HOSTESS_DOCKER_REGISTRY", "docker.io"),
         hostess_docker_image=os.environ.get("HOSTESS_DOCKER_IMAGE",
                                             "ocadotechnology/mirror-hostess"),
         hostess_docker_tag=os.environ.get("HOSTESS_DOCKER_TAG", "1.1.0"),

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 bitmath==1.3.3.1
-kubernetes==3.0.0a1
+kubernetes==11.0.0
 statsd==3.2.1

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ test_dependencies = [
 ]
 dependencies = [
     'bitmath==1.3.3.1',
-    'kubernetes==3.0.0a1',
+    'kubernetes==11.0.0',
     'statsd==3.2.1',
     ]
 
@@ -46,6 +46,7 @@ setup(
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.8',
     ],
     entry_points={
     },

--- a/tests/kubernetes_mock_responses.py
+++ b/tests/kubernetes_mock_responses.py
@@ -1,14 +1,14 @@
 import base64
 import json
 
-EMPTY_SERVICE = """{"api_version": "v1",
+EMPTY_SERVICE = """{"apiVersion": "v1",
      "kind": "Service",
      "metadata": {
                   "creation_timestamp": "2017-09-12T13:23:47Z",
                   "labels": {"app": "docker-registry", "mirror": "hub"},
                   "name": "registry-mirror-hub",
                   "namespace": "default",
-                  "ownerReferences": [{"api_version": "k8s.osp.tech/v1",
+                  "ownerReferences": [{"apiVersion": "k8s.osp.tech/v1",
                                         "kind": "RegistryMirror",
                                         "name": "hub",
                                         "uid": "c7137776-97b7-11e7-a6e5-0800276be3ff"}],
@@ -27,11 +27,11 @@ EMPTY_SERVICE = """{"api_version": "v1",
 
 EMPTY_DAEMON_SET = """{
     "kind":"DaemonSet",
-    "apiVersion":"extensions/v1beta1",
+    "apiVersion":"apps/v1",
     "metadata": {
                 "name":"registry-mirror-hub-utils",
                 "namespace":"default",
-                "selfLink":"/apis/extensions/v1beta1/namespaces/default/daemonsets/registry-mirror-hub-utils",
+                "selfLink":"/apis/apps/v1/namespaces/default/daemonsets/registry-mirror-hub-utils",
                 "uid":"dff71ac8-97c2-11e7-a6e5-0800276be3ff",
                 "resourceVersion":"18519",
                 "generation":1,
@@ -99,11 +99,11 @@ EMPTY_DAEMON_SET = """{
 
 EMPTY_STATEFUL_SET = """{
     "kind":"StatefulSet",
-    "apiVersion":"apps/v1beta1",
+    "apiVersion":"apps/v1",
     "metadata": {
         "name":"registry-mirror-hub",
         "namespace":"default",
-        "selfLink":"/apis/apps/v1beta1/namespaces/default/statefulsets/registry-mirror-hub",
+        "selfLink":"/apis/apps/v1/namespaces/default/statefulsets/registry-mirror-hub",
         "uid":"512e7799-97c4-11e7-a6e5-0800276be3ff",
         "resourceVersion":"20254",
         "generation":1,

--- a/tests/kubernetes_test_case.py
+++ b/tests/kubernetes_test_case.py
@@ -1,5 +1,7 @@
 from unittest import TestCase
-from kubernetes.config.incluster_config import SERVICE_HOST_ENV_NAME, SERVICE_PORT_ENV_NAME
+from kubernetes.config.incluster_config import (
+    SERVICE_HOST_ENV_NAME, SERVICE_PORT_ENV_NAME
+)
 import os
 import kubernetes
 import json
@@ -21,8 +23,12 @@ class KubernetesTestCase(TestCase):
             if exp_call != "GET":
                 body = json.loads(request.body)
                 self.assertIn(exp_metadata.name, body['metadata']['name'])
-                self.assertDictContainsSubset(exp_metadata.labels, body['metadata']['labels'])
-                self.assertEqual(body['metadata']['ownerReferences'][0]['name'], exp_metadata.owner_references[0].name)
+                self.assertDictContainsSubset(
+                    exp_metadata.labels,
+                    body['metadata']['labels'])
+                self.assertEqual(
+                    body['metadata']['ownerReferences'][0]['name'],
+                    exp_metadata.owner_references[0].name)
 
     def tearDown(self):
         os.remove("blip")

--- a/tests/test_operator.py
+++ b/tests/test_operator.py
@@ -7,12 +7,38 @@ from unittest.mock import patch, Mock
 from urllib3_mock import Responses
 from kubernetes.client.rest import ApiException
 
-TEST_DATA = [{"type": "CREATED", "object": {"metadata": {"name": "hub"},
-                                      "spec": {"upstreamUrl": "hubtest",
-                                                "credentialsSecret": "internal-mirror"}}},
-             {"type": "MODIFIED", "object": {"metadata": {"name": "hub"},
-                                      "spec": {"upstreamUrl": "hubtest",
-                                               "credentialsSecret": "internal-mirror"}}}]
+TEST_DATA = [
+    {
+        "type": "CREATED",
+        "object": {
+            "apiVersion": "k8s.osp.tech/v1",
+            "kind": "RegistryMirror",
+            "metadata": {
+                "name": "hub",
+                "uid": "db3c1f82-97c2-11e7-a6e5-08aa276be3ff",
+            },
+            "spec": {
+                "upstreamUrl": "hubtest",
+                "credentialsSecret": "internal-mirror"
+            }
+        }
+    },
+    {
+        "type": "MODIFIED",
+        "object": {
+            "apiVersion": "k8s.osp.tech/v1",
+            "kind": "RegistryMirror",
+            "metadata": {
+                "name": "hub",
+                "uid": "db3c1f82-97c2-11e7-a6e5-08aa276be3ff",
+            },
+            "spec": {
+                "upstreamUrl": "hubtest",
+                "credentialsSecret": "internal-mirror"
+            }
+        }
+    }
+]
 
 
 
@@ -46,9 +72,9 @@ class OperatorTestCase(KubernetesTestCase):
         stream_generator = stream_mock()
         responses.add('GET', '/api/v1/namespaces/default/services/registry-mirror-hub', EMPTY_SERVICE)
         responses.add('GET', '/api/v1/namespaces/default/services/registry-mirror-hub-headless', EMPTY_SERVICE)
-        responses.add('GET', '/apis/extensions/v1beta1/namespaces/default/daemonsets/registry-mirror-hub-utils',
+        responses.add('GET', '/apis/apps/v1/namespaces/default/daemonsets/registry-mirror-hub-utils',
                       EMPTY_DAEMON_SET)
-        responses.add('GET', '/apis/apps/v1beta1/namespaces/default/statefulsets/registry-mirror-hub',
+        responses.add('GET', '/apis/apps/v1/namespaces/default/statefulsets/registry-mirror-hub',
                       EMPTY_STATEFUL_SET)
         responses.add('GET', '/api/v1/namespaces/default/secrets/registry-mirror-hub-secret',
                       '{}')
@@ -56,8 +82,8 @@ class OperatorTestCase(KubernetesTestCase):
                       VALID_SECRET)
         responses.add('PUT', '/api/v1/namespaces/default/services/registry-mirror-hub', '')
         responses.add('PUT', '/api/v1/namespaces/default/services/registry-mirror-hub', '')
-        responses.add('PUT', '/apis/extensions/v1beta1/namespaces/default/daemonsets/registry-mirror-hub-utils', '')
-        responses.add('PUT', '/apis/apps/v1beta1/namespaces/default/statefulsets/registry-mirror-hub', '')
+        responses.add('PUT', '/apis/apps/v1/namespaces/default/daemonsets/registry-mirror-hub-utils', '')
+        responses.add('PUT', '/apis/apps/v1/namespaces/default/statefulsets/registry-mirror-hub', '')
         responses.add('PUT', '/api/v1/namespaces/default/secrets/registry-mirror-hub-secret', '')
         with patch('kubernetes.watch.watch.Watch.stream', return_value=stream_generator):
             self.operator.watch_registry_mirrors()
@@ -73,23 +99,31 @@ class OperatorTestCase(KubernetesTestCase):
                              labels={"app": "docker-registry",
                                     "mirror": "hub"},
                              owner_references=[kubernetes.client.V1OwnerReference(
-                                api_version=None,
+                                api_version="k8s.osp.tech/v1",
                                 name="hub",
-                                kind=None,
-                                uid=None,
+                                kind="RegistryMirror",
+                                uid="not-none",
                              )]
                             )
                          )
 
     @responses.activate
     def test_will_read_crds_blanks_dont_exist(self):
-        '''Should listen to CRDs being streamed + call apis appropriately. In this case the objects don't already exist'''
+        '''Should listen to CRDs being streamed and call apis appropriately. In this case the objects don't already exist'''
         stream_generator = stream_mock()
-        responses.add('GET', '/api/v1/namespaces/default/services/registry-mirror-hub', status=404, body='{"kind":"Status","apiVersion":"v1","metadata":{},"status":"Failure","message":"services \\"registry-mirror-internal\\" not found","reason":"NotFound","details":{"name":"registry-mirror-internal","kind":"services"},"code":404}')
+        responses.add(
+            'GET',
+            '/api/v1/namespaces/default/services/registry-mirror-hub',
+            status=404,
+            body='{"kind":"Status","apiVersion":"v1","metadata":{},'
+            '"status":"Failure","message":"services \\"registry-mirror-'
+            'internal\\" not found","reason":"NotFound","details":'
+            '{"name":"registry-mirror-internal","kind":"services"},"code":404}'
+        )
         responses.add('GET', '/api/v1/namespaces/default/services/registry-mirror-hub-headless', status=404)
-        responses.add('GET', '/apis/apps/v1beta1/namespaces/default/statefulsets/registry-mirror-hub',
+        responses.add('GET', '/apis/apps/v1/namespaces/default/statefulsets/registry-mirror-hub',
                       status=404)
-        responses.add('GET', '/apis/extensions/v1beta1/namespaces/default/daemonsets/registry-mirror-hub-utils',
+        responses.add('GET', '/apis/apps/v1/namespaces/default/daemonsets/registry-mirror-hub-utils',
                       status=404)
         responses.add('GET', '/api/v1/namespaces/default/secrets/registry-mirror-hub-secret',
                       status=404)
@@ -97,15 +131,16 @@ class OperatorTestCase(KubernetesTestCase):
                       VALID_SECRET)
         responses.add('POST', '/api/v1/namespaces/default/services', EMPTY_SERVICE)
         responses.add('POST', '/api/v1/namespaces/default/services', EMPTY_SERVICE)
-        responses.add('POST', '/apis/apps/v1beta1/namespaces/default/statefulsets',
+        responses.add('POST', '/apis/apps/v1/namespaces/default/statefulsets',
                       EMPTY_STATEFUL_SET)
-        responses.add('POST', '/apis/extensions/v1beta1/namespaces/default/daemonsets',
+        responses.add('POST', '/apis/apps/v1/namespaces/default/daemonsets',
                       EMPTY_DAEMON_SET)
         responses.add('POST', '/api/v1/namespaces/default/secrets', '')
         with patch('kubernetes.watch.watch.Watch.stream', return_value=stream_generator):
             self.operator.watch_registry_mirrors()
-        # none of the objects exist, so 4 gets, followed by 2 service posts, followed by 2 service puts,
-        # followed by post/put/post/put for daemon set/stateful set
+        # none of the objects exist, so 4 gets, followed by 2 service posts,
+        # followed by 2 service puts, followed by post/put/post/put for daemon
+        # set/stateful set
         methods = ('GET', 'GET', 'GET', 'GET', 'GET',
                    'POST', 'POST',
                    'POST', 'POST', 'GET', 'POST',
@@ -119,10 +154,10 @@ class OperatorTestCase(KubernetesTestCase):
                              labels={"app": "docker-registry",
                                     "mirror": "hub"},
                              owner_references=[kubernetes.client.V1OwnerReference(
-                                api_version=None,
+                                api_version="k8s.osp.tech/v1",
                                 name="hub",
-                                kind=None,
-                                uid=None,
+                                kind="RegistryMirror",
+                                uid="not-none",
                              )]
                             )
                          )

--- a/tests/test_regmirror.py
+++ b/tests/test_regmirror.py
@@ -1,13 +1,13 @@
 from mirroroperator.registrymirror import RegistryMirror
 from tests.kubernetes_test_case import KubernetesTestCase
 from tests.kubernetes_mock_responses import (
-    EMPTY_SERVICE, EMPTY_STATEFUL_SET, VALID_SECRET, EMPTY_DAEMON_SET,
-    username, password, INVALID_SECRET
+    EMPTY_SERVICE,
+    EMPTY_STATEFUL_SET,
+    EMPTY_DAEMON_SET,
+    VALID_SECRET,
 )
 from urllib3_mock import Responses
 import kubernetes
-import json
-import base64
 from copy import deepcopy
 responses = Responses('urllib3')
 
@@ -20,20 +20,30 @@ class CustomResourceTestCase(KubernetesTestCase):
             "hostess_docker_registry": "docker.io",
             "hostess_docker_image": "ocadotechnology/mirror-hostess",
             "hostess_docker_tag": 2,
-            "ss_ds_labels":{"test":"test_labels"},
-            "ss_ds_template_labels":{"test": "test_pod_labels"},
-            "ss_ds_tolerations": [{"key": "some.tol.era/tion", "operator": "Exists"}],
+            "ss_ds_labels": {"test": "test_labels"},
+            "ss_ds_template_labels": {"test": "test_pod_labels"},
+            "ss_ds_tolerations": [
+                {"key": "some.tol.era/tion", "operator": "Exists"}
+            ],
             "image_pull_secrets": None,
             "docker_certificate_secret": VALID_SECRET,
             "ca_certificate_bundle": None,
         }
-        registry_kwargs = {"metadata": {"name": "hub"},
-                           "spec": {"upstreamUrl": "hubtest"}}
+        registry_kwargs = {
+            "apiVersion": "k8s.osp.tech/v1",
+            "kind": "RegistryMirror",
+            "metadata": {
+                "name": "hub",
+                "uid": "db3c1f82-97c2-11e7-a6e5-08aa276be3ff",
+            },
+            "spec": {"upstreamUrl": "hubtest"}
+        }
         registry_kwargs.update(self.env_var_dict)
         self.mirror = RegistryMirror(event_type="CREATED", **registry_kwargs)
 
         registry_kwargs_with_credential_secret = deepcopy(registry_kwargs)
-        registry_kwargs_with_credential_secret['spec']["credentialsSecret"] = "internal-mirror"
+        registry_kwargs_with_credential_secret["spec"][
+            "credentialsSecret"] = "internal-mirror"
         registry_kwargs_with_credential_secret.update(self.env_var_dict)
         self.mirror_with_credential_secret = RegistryMirror(
             event_type="CREATED", **registry_kwargs_with_credential_secret)
@@ -103,11 +113,11 @@ class CustomResourceTestCase(KubernetesTestCase):
         '''Should replace 1 empty daemon set'''
         responses.add(
             'PUT',
-            ('/apis/extensions/v1beta1/namespaces/default/daemonsets/registry'
+            ('/apis/apps/v1/namespaces/default/daemonsets/registry'
              '-mirror-hub-utils'),
             ''
         )
-        self.mirror.update_daemon_set(kubernetes.client.V1beta1DaemonSet())
+        self.mirror.update_daemon_set(kubernetes.client.V1DaemonSet())
         self.check_calls(('PUT',), responses.calls, self.mirror.metadata)
 
     @responses.activate
@@ -115,7 +125,7 @@ class CustomResourceTestCase(KubernetesTestCase):
         '''Should create then replace a daemon set'''
         responses.add(
             'POST',
-            '/apis/extensions/v1beta1/namespaces/default/daemonsets',
+            '/apis/apps/v1/namespaces/default/daemonsets',
             body=EMPTY_DAEMON_SET
         )
         self.mirror.update_daemon_set(None)
@@ -126,13 +136,15 @@ class CustomResourceTestCase(KubernetesTestCase):
         '''Should replace 1 empty stateful set'''
         responses.add(
             'PUT',
-            ('/apis/apps/v1beta1/namespaces/default/statefulsets/registry'
+            ('/apis/apps/v1/namespaces/default/statefulsets/registry'
              '-mirror-hub'),
             ''
         )
-        self.mirror.update_stateful_set(kubernetes.client.V1beta1StatefulSet(
-            spec=kubernetes.client.V1beta1StatefulSetSpec(
-
+        self.mirror.update_stateful_set(kubernetes.client.V1StatefulSet(
+            spec=kubernetes.client.V1StatefulSetSpec(
+                service_name=self.mirror.full_name + "-headless",
+                selector=self.mirror.labels,
+                template=kubernetes.client.V1PodTemplateSpec(),
             )
         ))
         self.check_calls(('PUT',), responses.calls, self.mirror.metadata)
@@ -142,7 +154,7 @@ class CustomResourceTestCase(KubernetesTestCase):
         '''Should create then replace a statefulset'''
         responses.add(
             'POST',
-            '/apis/apps/v1beta1/namespaces/default/statefulsets',
+            '/apis/apps/v1/namespaces/default/statefulsets',
             body=EMPTY_STATEFUL_SET
         )
         self.mirror.update_stateful_set(None)


### PR DESCRIPTION
Part of osp-cfc-platform/backlog#1402

Sorry there's a bunch of style changes, editor linter makes it painful not to fix them.

Main goal of this was to avoid using deprecated API, mainly things moving from extensions/v1beta1 to apps/v1. 