### PR TITLE
ci: bring travis python up to date

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: python
 python:
-- '3.6'
+- '3.8'
 sudo: required
 services:
 - docker


### PR DESCRIPTION
Dockerfile is using 3.8 and tests for the last PR were locally run on 3.8, forgot to add this.

Part of osp-cfc-platform/backlog#1402