### PR TITLE
Improve daemonsets

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Name | description | default
 DOCKER_CERTIFICATE_SECRET | You **must** provide a certificate to enable TLS between the docker daemon and the registry and create a secret from it, this variable is the name of the secret | None
 NAMESPACE | The namespace in which the resources should be created. This should be the same namespace as where the container is running | default 
 SECONDS_BETWEEN_STREAMS | Time to sleep between calls to the API. The operator will occasionally lose connection or else fail to run if the Custom Resource Definition does not exist. | 30
-HOSTESS_DOCKER_REGISTRY | The docker registry where mirror-hostess is to be pulled from. | docker.io 
+HOSTESS_DOCKER_REGISTRY | The docker registry where mirror-hostess and alpine are to be pulled from. | docker.io
 HOSTESS_DOCKER_IMAGE | The name of the docker image for mirror-hostess. | ocadotechnology/mirror-hostess
 HOSTESS_DOCKER_TAG | The tag for the mirror-hostess docker image. | 1.1.0
 SS_DS_LABELS | (Optional) StatefulSet and DaemonSet labels | None

--- a/mirroroperator/registrymirror.py
+++ b/mirroroperator/registrymirror.py
@@ -298,7 +298,8 @@ class RegistryMirror(object):
                                     "-u",
                                     "-x"
                                 ],
-                                image="alpine:3.6",
+                                image="{}/alpine:3.6".format(
+                                    self.hostess_docker_registry),
                                 image_pull_policy="IfNotPresent",
                                 resources=client.V1ResourceRequirements(
                                     requests={"memory": "1Mi", "cpu": "0.001"},

--- a/mirroroperator/registrymirror.py
+++ b/mirroroperator/registrymirror.py
@@ -264,7 +264,7 @@ class RegistryMirror(object):
                                     self.hostess_docker_registry,
                                     self.hostess_docker_image,
                                     self.hostess_docker_tag),
-                                image_pull_policy="Always",
+                                image_pull_policy="IfNotPresent",
                                 resources=client.V1ResourceRequirements(
                                     requests={
                                         "memory": "64Mi", "cpu": "0.001"
@@ -299,7 +299,7 @@ class RegistryMirror(object):
                                     "-x"
                                 ],
                                 image="alpine:3.6",
-                                image_pull_policy="Always",
+                                image_pull_policy="IfNotPresent",
                                 resources=client.V1ResourceRequirements(
                                     requests={"memory": "1Mi", "cpu": "0.001"},
                                     limits={"memory": "32Mi", "cpu": "0.1"}


### PR DESCRIPTION
* feat: pull 'certificate-installation' image from the same mirror as for 'hostess'
    HOSTESS_DOCKER_REGISTRY env var now sets registry host for both
    images in registry-mirror Daemonsets.
* fix: change imagePullPolicy for certificate-installation containers
    Reduces number of pulls from Docker Hub when container restarts/node reboots.
