### PR TITLE
fix: restore table formatting in README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ If you're confused what an operator is, [this blog post][operators] will give yo
 The following environment variables can be set:
 
 Name | description | default
---- | --- | --- | ---
+--- | --- | ---
 DOCKER_CERTIFICATE_SECRET | (Required) You **must** provide a certificate to enable TLS between the docker daemon and the registry and create a secret from it, this variable is the name of the secret | None
 NAMESPACE | (Optional) The namespace in which the resources should be created. This should be the same namespace as where the container is running | default
 SECONDS_BETWEEN_STREAMS | (Optional) Time to sleep between calls to the API. The operator will occasionally lose connection or else fail to run if the Custom Resource Definition does not exist. | 30


### PR DESCRIPTION
It was broken in PR #56