### PR TITLE
fix: set priorityClass for DaemonSets too

### DIFF
--- a/mirroroperator/registrymirror.py
+++ b/mirroroperator/registrymirror.py
@@ -353,7 +353,8 @@ class RegistryMirror(object):
                                      secret=client.V1SecretVolumeSource(
                                          secret_name=self.docker_certificate_secret
                                      )
-                                 )]
+                                 )],
+                        priority_class_name=self.priority_class
                     )
                 ),
                 update_strategy=client.V1DaemonSetUpdateStrategy(


### PR DESCRIPTION
The option to set priorityClass for StatefulSets was
added in #51. DaemonSets must have it too.