### PR TITLE
feat: introduce command-line switches for liveness probe support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.8-alpine3.12
+FROM python:3.8-alpine3.14
 RUN apk --no-cache add curl
 COPY . ./app
 WORKDIR /app

--- a/README.md
+++ b/README.md
@@ -60,6 +60,24 @@ is installed into `/etc/docker/certs.d/<masqueradeUrl>/` directory. In "services
 is installed into `/etc/docker/certs.d/<clusterIp>/`, where `<clusterIp>` is the IP address of the caching
 proxy service.
 
+### Detecting the unexpected `imageswap-map` changes
+
+There is a possibility that, while operating in the 'services' mode, config map for ImageSwap,
+`imageswap-maps`, is modified by hands or by another deployment. With this, mirror-operator
+will not detect these changes, and would not update the config map.
+With the use of the `--map-check` command-line switch it is possible to discover such a situation.
+For this, aadd the livenessProbe like this:
+```
+        livenessProbe:
+          exec:
+            command:
+            - /usr/local/bin/python
+            - /app/mirroroperator/operator.py
+            - --map-check
+```
+Having this configured, the unexpected change in the Config Map is detected and
+the container is restarted.
+
 ## Configuration
 The following environment variables can be set:
 

--- a/mirroroperator/operator.py
+++ b/mirroroperator/operator.py
@@ -1,9 +1,12 @@
 import ast
+import argparse
 import json
 import logging
 import time
 import os
+import sys
 from http import HTTPStatus
+import fasteners
 import kubernetes
 
 from kubernetes.client.rest import ApiException
@@ -17,12 +20,11 @@ CRD_GROUP = "k8s.osp.tech"
 CRD_VERSION = "v1"
 CRD_PLURAL = "registrymirrors"
 
+VERSION_FILE="/var/run/imageswap_configmap_version"
+
 
 # pylint: disable=too-few-public-methods
 class MirrorOperator:
-    # pylint: disable=fixme
-    # FIXME: pylint warning: redefined-outer-name: Redefining name 'env_vars' from outer scope
-    # pylint: disable=redefined-outer-name
     def __init__(self, env_vars):
         """
         :param env_vars: dictionary includes namespace,
@@ -32,7 +34,8 @@ class MirrorOperator:
             ss_ds_template_lables (used in RegistryMirror, optional)
             ss_ds_tolerations (used in RegistryMirror, optional)
             addressing_scheme ('hostess' or 'services', defaults to 'hostess', optional)
-            imageswap_namespace (used in MirrorOperator, default to the operator namespace, optional)
+            imageswap_namespace (used in MirrorOperator,
+                                 default to the operator namespace, optional)
             hostess_docker_image (used in RegistryMirror),
             hostess_docker_tag (used in RegistryMirror),
             image_pull_secrets(used in RegistryMirror, optional),
@@ -45,6 +48,7 @@ class MirrorOperator:
         kubernetes.config.load_incluster_config()
         self.object_api = kubernetes.client.CustomObjectsApi()
         self.core_api = kubernetes.client.CoreV1Api()
+        self.cm_lock = fasteners.InterProcessLock(VERSION_FILE + ".lck")
 
     def watch_registry_mirrors(self):
         watcher = kubernetes.watch.Watch()
@@ -103,18 +107,45 @@ class MirrorOperator:
             imageswap_config += "{0}:{1}/{0}\n".format(masqueraded_name, service_ip)
         LOGGER.info("Imageswap config: %s", imageswap_config)
         imageswap_namespace = self.registry_mirror_vars['imageswap_namespace']
-        self.core_api.patch_namespaced_config_map(
+
+        self.cm_lock.acquire()
+
+        configmap = self.core_api.patch_namespaced_config_map(
                 "imageswap-maps",
                 imageswap_namespace,
                 {"data": {"maps": imageswap_config}}
         )
 
+        with open(VERSION_FILE, "w", encoding='utf-8') as store:
+            store.write(configmap.metadata.resource_version)
+
+        self.cm_lock.release()
+
+    def is_imageswap_config_current(self):
+        imageswap_namespace = self.registry_mirror_vars['imageswap_namespace']
+
+        self.cm_lock.acquire()
+        configmap = self.core_api.read_namespaced_config_map(
+                "imageswap-maps",
+                imageswap_namespace
+        )
+        self.cm_lock.release()
+
+        with open(VERSION_FILE, "r", encoding='utf-8') as store:
+            stored_cm_version = store.read()
+            if stored_cm_version == configmap.metadata.resource_version:
+                sys.exit()
+            else:
+                LOGGER.error("Configmap has been modified not by the mirror operator")
+                sys.exit(1)
+
+
+        return False
+
 def safely_eval_env(env_var):
     return ast.literal_eval(os.environ.get(env_var)
                             ) if os.environ.get(env_var) is not None else None
-
-
-if __name__ == '__main__':
+def main():
     logging.basicConfig(level=logging.INFO)
 
     # Get organization specific variables from env
@@ -151,8 +182,38 @@ if __name__ == '__main__':
 
     operator = MirrorOperator(env_vars)
 
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--map-update",
+                        help="Update the imageswap-maps Config Map",
+                        action='store_true')
+    parser.add_argument("--map-check",
+                        help="Check the version of the imageswap-maps Config Map",
+                        action='store_true')
+    args = parser.parse_args()
+
+    if ( args.map_update or args.map_check ) and env_vars["addressing_scheme"] != "services":
+        LOGGER.error(
+            "ERROR: --map-update or --map-check with the '%s' addressing scheme is invalid",
+            env_vars["addressing_scheme"]
+        )
+        sys.exit(1)
+
+    if args.map_update:
+        operator.update_imageswap_config()
+        sys.exit()
+
+    if args.map_check:
+        map_current = operator.is_imageswap_config_current()
+        if map_current:
+            sys.exit()
+        else:
+            sys.exit(1)
+
     sleep_time = os.environ.get("SECONDS_BETWEEN_STREAMS", 30)
     while True:
         operator.watch_registry_mirrors()
         LOGGER.info("API closed connection, sleeping for %i seconds", sleep_time)
         time.sleep(sleep_time)
+
+if __name__ == '__main__':
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 bitmath==1.3.3.1
+fasteners==0.14.1
 kubernetes==11.0.0
 statsd==3.2.1


### PR DESCRIPTION
Impact: MINOR

1. There is a possibility that, while operating in the 'services' mode, config map for ImageSwap, `imageswap-maps`, is modified by hands or by another deployment. With this, mirror-operator will not detect these changes, and would not update the config map.

This PRs add the `--map-check` command-line switch intended to provide support for discovering such a situation. It's possible then to use `livenessProbe` like this:
```
        livenessProbe:
          exec:
            command:
            - /usr/local/bin/python
            - /app/mirroroperator/operator.py
            - --map-check
```
2. Command-line switch `--map-update` is added. With this flag it's possible to regenerate `imageswap-maps` by calling the `operator.py --map-update`
3. Bump base docker image to get rid of Snyk warnings (now is `Tested 40 dependencies for known issues, no vulnerable paths found`)
4. Some code clean-up.